### PR TITLE
Assigning Tech Lead

### DIFF
--- a/ASSIGNtechlead.sql
+++ b/ASSIGNtechlead.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Employee_Projects
+  ADD COLUMN isTechLead bool,
+  ADD CONSTRAINT unique_tech_lead_per_project UNIQUE (projectId, isTechLead);


### PR DESCRIPTION
6 "As a member of the Management team I want to be able to assign a delivery employee as a Tech Lead to a project. Each project can only have 1 Tech Lead"


Altered Employee_Projects Table to include boolean IsTechLead to identify if employee working on project is the tech lead. Created a unique constraint, unique_tech_lead_per_project, ensures only one employee is the tech lead per project. 