### PR TITLE
Assign Client To Project

### DIFF
--- a/ASSIGNclientTOProject.sql
+++ b/ASSIGNclientTOProject.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Project
+  ADD COLUMN clientId,
+  ADD CONSTRAINT fk_clientProject FOREIGN KEY (clientId) REFERENCES `Client`(clientId);


### PR DESCRIPTION
8. "As a member of the Sales team I want to be able to assign a client to a project. A client can have multiple projects but a project can only have 1 client"

Altered Project table to include clientID as a foreign key, so a client can be assigned to a project.